### PR TITLE
fix: allow classnames to be added through props, and fix standard fun…

### DIFF
--- a/lib/classy.js
+++ b/lib/classy.js
@@ -5,11 +5,12 @@ import { buildClassName } from './utils/class-name';
 
 const classy = (tag, parentClassName) => (strings, ...interpolations) => {
   const className =
-    classnames(parentClassName, buildClassName(strings, interpolations));
-
+    classnames(parentClassName, buildClassName(strings, ...interpolations));
   // eslint-disable-next-line
   const ClassyComponent =
-    props => createElement(tag, { className, ...props }, props.children);
+    props => createElement(tag,
+      { ...props, className: classnames(props.className, className) },
+      props.children);
   ClassyComponent.classy = { tag, className };
   return ClassyComponent;
 };

--- a/lib/classy.test.js
+++ b/lib/classy.test.js
@@ -9,14 +9,42 @@ it('creates a function', () => {
   expect(classy.div`foo`).toBeInstanceOf(Function);
 });
 
-it('renders', () => {
+it('renders w/ classnames that are passed in', () => {
   const Component = classy.div`foo`;
   const div = document.createElement('div');
   ReactDOM.render(<Component>foo</Component>, div);
+  expect(div.getElementsByClassName('foo')).toHaveLength(1);
 });
 
-it('adds classes', () => {
-  // const Component = classy.div`foo`;
-  // const element = <Component>foo</Component>;
-  // expect(element.props.className).toBe('foo'); // ?
+it('renders with additional classnames, if passed in through the prop, does not override', () => {
+  const Component = classy.div`foo`;
+  const div = document.createElement('div');
+  ReactDOM.render(<Component className="otherClassName">foo</Component>, div);
+  const divsWithClassName = div.getElementsByClassName('otherClassName');
+  expect(divsWithClassName).toHaveLength(1);
+  expect(divsWithClassName[0].className).toContain('otherClassName');
+  expect(divsWithClassName[0].className).toContain('foo');
+});
+
+it('renders with additional classnames, if passed in through the prop, does not override; works with extensions and std function notation', () => {
+  const Button = classy.button(`btn-default`);
+  const PrimaryButton = classy(Button)(`btn-primary`);
+  const div = document.createElement('div');
+  ReactDOM.render(<PrimaryButton className="addedClass">foo</PrimaryButton>, div);
+  const divsWithClassName = div.getElementsByClassName('addedClass');
+  expect(divsWithClassName).toHaveLength(1);
+  expect(divsWithClassName[0].className).toContain('btn-default');
+  expect(divsWithClassName[0].className).toContain('btn-primary');
+  expect(divsWithClassName[0].className).toContain('addedClass');
+});
+
+it('renders properly with the array notation, and passed in props class name should work', () => {
+  const PrimaryButton = classy.button([`btn-default`, 'btn-primary']);
+  const div = document.createElement('div');
+  ReactDOM.render(<PrimaryButton className="addedClass">foo</PrimaryButton>, div);
+  const divsWithClassName = div.getElementsByClassName('addedClass');
+  expect(divsWithClassName).toHaveLength(1);
+  expect(divsWithClassName[0].className).toContain('btn-default');
+  expect(divsWithClassName[0].className).toContain('btn-primary');
+  expect(divsWithClassName[0].className).toContain('addedClass');
 });


### PR DESCRIPTION
…ction notation being trimmed

Fixes two things:
- props.className overrides everything
```jsx
const Component = classy.div`foo`;
<Component className="otherClassName">foo</Component>
// should have className foo otherClassName, but it doesn't, just has otherClassName
```
- standard function notation not working see #1




Closes #1